### PR TITLE
Release v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.1] - 2026-04-08
+
 ### Added
 - **Deployment examples** — Docker Compose, Helm chart, and Kustomize manifests in `examples/`
 - **Helm chart repository** — published to GitHub Pages via chart-releaser-action
@@ -133,6 +135,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Docker support
 - Air hot reload for development
 
-[Unreleased]: https://github.com/Cepat-Kilat-Teknologi/go-snmp-olt-zte-c320/compare/v2.1.0...HEAD
+[Unreleased]: https://github.com/Cepat-Kilat-Teknologi/go-snmp-olt-zte-c320/compare/v2.1.1...HEAD
+[2.1.1]: https://github.com/Cepat-Kilat-Teknologi/go-snmp-olt-zte-c320/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/Cepat-Kilat-Teknologi/go-snmp-olt-zte-c320/compare/v1.0.0...v2.1.0
 [1.0.0]: https://github.com/Cepat-Kilat-Teknologi/go-snmp-olt-zte-c320/releases/tag/v1.0.0

--- a/GUIDES.md
+++ b/GUIDES.md
@@ -184,7 +184,7 @@ version: '3.8'
 
 services:
   app:
-    image: cepatkilatteknologi/snmp-olt-zte-c320:2.1.0
+    image: cepatkilatteknologi/snmp-olt-zte-c320:2.1.1
     environment:
       - REDIS_HOST=external.redis.host  # External Redis
       - REDIS_PORT=6379
@@ -227,7 +227,7 @@ docker run -d \
   -e REDIS_MIN_IDLE_CONNECTIONS=10 \
   -e REDIS_POOL_SIZE=100 \
   -e REDIS_POOL_TIMEOUT=30 \
-  cepatkilatteknologi/snmp-olt-zte-c320:2.1.0
+  cepatkilatteknologi/snmp-olt-zte-c320:2.1.1
 
 # Verify
 docker logs -f go-snmp-olt
@@ -247,7 +247,7 @@ docker run -d \
   -e REDIS_HOST=external.redis.host \
   -e REDIS_PORT=6379 \
   -e REDIS_PASSWORD=YOUR_REDIS_PASSWORD \
-  cepatkilatteknologi/snmp-olt-zte-c320:2.1.0
+  cepatkilatteknologi/snmp-olt-zte-c320:2.1.1
 ```
 
 #### With HTTPS/TLS
@@ -267,7 +267,7 @@ docker run -d \
   -e SNMP_COMMUNITY=your_snmp_community \
   -e REDIS_HOST=redis-olt \
   -e REDIS_PORT=6379 \
-  cepatkilatteknologi/snmp-olt-zte-c320:2.1.0
+  cepatkilatteknologi/snmp-olt-zte-c320:2.1.1
 ```
 
 ### Kubernetes
@@ -371,7 +371,7 @@ spec:
     spec:
       containers:
       - name: go-snmp-olt
-        image: cepatkilatteknologi/snmp-olt-zte-c320:2.1.0
+        image: cepatkilatteknologi/snmp-olt-zte-c320:2.1.1
         ports:
         - containerPort: 8081
         env:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![ci](https://github.com/Cepat-Kilat-Teknologi/go-snmp-olt-zte-c320/actions/workflows/ci.yml/badge.svg)](https://github.com/Cepat-Kilat-Teknologi/go-snmp-olt-zte-c320/actions/workflows/ci.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/Cepat-Kilat-Teknologi/go-snmp-olt-zte-c320)](https://goreportcard.com/report/github.com/Cepat-Kilat-Teknologi/go-snmp-olt-zte-c320)
 [![codecov](https://codecov.io/gh/Cepat-Kilat-Teknologi/go-snmp-olt-zte-c320/graph/badge.svg?token=NB3N7GMUX3)](https://codecov.io/gh/Cepat-Kilat-Teknologi/go-snmp-olt-zte-c320)
-[![Helm Chart](https://img.shields.io/badge/helm-v2.1.0-blue)](https://github.com/Cepat-Kilat-Teknologi/go-snmp-olt-zte-c320/releases/tag/v2.1.0)
+[![Helm Chart](https://img.shields.io/badge/helm-v2.1.1-blue)](https://github.com/Cepat-Kilat-Teknologi/go-snmp-olt-zte-c320/releases/tag/v2.1.1)
 
 REST API service for monitoring ZTE C320 OLT devices via SNMP protocol, built with Go. Provides real-time ONU information including status, optical power levels, uptime, and serial numbers across all board/PON combinations.
 
@@ -81,7 +81,7 @@ docker run -d -p 8081:8081 --name go-snmp-olt-zte-c320 \
 -e REDIS_MIN_IDLE_CONNECTIONS=10 -e REDIS_POOL_SIZE=100 \
 -e REDIS_POOL_TIMEOUT=30 -e SNMP_HOST=x.x.x.x \
 -e SNMP_PORT=161 -e SNMP_COMMUNITY=xxxx \
-cepatkilatteknologi/snmp-olt-zte-c320:2.1.0
+cepatkilatteknologi/snmp-olt-zte-c320:2.1.1
 ```
 
 ## API Endpoints

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -390,7 +390,7 @@ gosec ./...
 **3. Container Scanning:**
 ```bash
 # Using Trivy
-trivy image cepatkilatteknologi/snmp-olt-zte-c320:2.1.0
+trivy image cepatkilatteknologi/snmp-olt-zte-c320:2.1.1
 ```
 
 ## Additional Resources

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -5,7 +5,7 @@ info:
     REST API for monitoring ZTE C320 OLT (Optical Line Terminal) via SNMP.
     Provides endpoints to query ONU status, optical power levels, serial numbers,
     and manage cache for board/PON combinations.
-  version: 2.1.0
+  version: 2.1.1
   contact:
     name: API Support
   license:

--- a/examples/README.md
+++ b/examples/README.md
@@ -51,6 +51,6 @@ kubectl apply -k examples/kustomize/overlays/development/
 
 ## Image
 
-All examples use `cepatkilatteknologi/snmp-olt-zte-c320:2.1.0` by default.
+All examples use `cepatkilatteknologi/snmp-olt-zte-c320:2.1.1` by default.
 
 Available tags: `latest`, `2.1.0`, `2.1`, `2`

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -1,6 +1,6 @@
 # Docker Deployment Examples
 
-Docker deployment patterns for `cepatkilatteknologi/snmp-olt-zte-c320:2.1.0`.
+Docker deployment patterns for `cepatkilatteknologi/snmp-olt-zte-c320:2.1.1`.
 
 The application listens on **TCP 8081** (HTTP API) and **UDP 1620** (SNMP Trap).
 
@@ -27,7 +27,7 @@ docker run -d \
   -e SNMP_COMMUNITY=public \
   -e TRAP_ENABLED=true \
   -e TZ=Asia/Jakarta \
-  cepatkilatteknologi/snmp-olt-zte-c320:2.1.0
+  cepatkilatteknologi/snmp-olt-zte-c320:2.1.1
 ```
 
 ## 2. With Redis (recommended)

--- a/examples/docker/docker-compose.yaml
+++ b/examples/docker/docker-compose.yaml
@@ -6,7 +6,7 @@
 
 services:
   app:
-    image: cepatkilatteknologi/snmp-olt-zte-c320:2.1.0
+    image: cepatkilatteknologi/snmp-olt-zte-c320:2.1.1
     container_name: snmp-olt-zte-c320
     restart: unless-stopped
 

--- a/examples/helm/snmp-olt-zte-c320/Chart.yaml
+++ b/examples/helm/snmp-olt-zte-c320/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: snmp-olt-zte-c320
 description: Monitoring OLT ZTE C320 via SNMP - REST API with Redis caching
 type: application
-version: 2.1.0
-appVersion: "2.1.0"
+version: 2.1.1
+appVersion: "2.1.1"
 
 dependencies:
   - name: redis

--- a/examples/kustomize/base/deployment.yaml
+++ b/examples/kustomize/base/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: snmp-olt-zte-c320
-          image: cepatkilatteknologi/snmp-olt-zte-c320:2.1.0
+          image: cepatkilatteknologi/snmp-olt-zte-c320:2.1.1
           ports:
             - name: http
               containerPort: 8081


### PR DESCRIPTION
## v2.1.1 Patch Release

### Fixed
- Docker image name standardized to `cepatkilatteknologi/snmp-olt-zte-c320`
- Helm `_helpers.tpl` Redis host resolution (fullname → Release.Name)
- Kustomize secret `API_KEY` default empty
- `SERVER_PORT` hardcoded to 8081 inside Docker container

### Changed
- Production deployment consolidated to `examples/docker/`
- Removed `docker-compose.prod.yaml`
- golangci-lint upgraded to v2.11.4

### Added
- Deployment examples (Docker Compose, Helm, Kustomize)
- Helm chart publishing to GitHub Pages
- GitHub Release with install instructions

### Tested
- [x] Docker Compose: 9/9 endpoints pass
- [x] Helm on local K8s: 8/8 endpoints pass
- [x] Kustomize on local K8s: 8/8 endpoints pass
- [x] go test -race: all pass, 0 race conditions
- [x] golangci-lint: 0 issues
- [x] No sensitive data in diff