### PR TITLE
fix(snmp): set GETBULK MaxRepetitions (default 20, env SNMP_MAX_REPETITIONS)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,17 @@ SNMP_COMMUNITY=public
 # SNMP_MAX_CONCURRENT: Maximum concurrent SNMP operations to OLT device
 # Prevents OLT saturation under high API load. Increase if OLT can handle more.
 SNMP_MAX_CONCURRENT=5
+# SNMP_TIMEOUT_SECONDS: Per-request SNMP timeout (default: 5). Raise for slow/public links.
+SNMP_TIMEOUT_SECONDS=5
+# SNMP_RETRIES: Per-request SNMP retry count (default: 2).
+SNMP_RETRIES=2
+# SNMP_MAX_REPETITIONS: GETBULK max-repetitions for BulkWalk (default: 20).
+# MUST be > 0: a GetBulk with max-repetitions=0 HANGS on some ZTE OLTs
+# (proven on a ZTE C300 V2.1.0 — -Cr0 never returns, -Cr10/-Cr50 return in
+# <0.1s). The default 20 makes GetBulk usable, so the per-OLT walk=true
+# (GetNext) workaround is no longer needed just to read these devices.
+# Any value <= 0 or non-numeric falls back to the safe default.
+SNMP_MAX_REPETITIONS=20
 
 # ------------------------------------------------------------------------------
 # Redis Configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — GetBulk hang from unset SNMP max-repetitions
+- **SNMP connections now always set a non-zero GETBULK max-repetitions.**
+  `createConnection` (and the seed builder in `pkg/snmp`) configured `Timeout`,
+  `Retries`, and `MaxOids` but never `MaxRepetitions`, leaving it at the gosnmp
+  zero value (0). A GetBulk with max-repetitions=0 **hangs** on some ZTE OLTs:
+  proven live on a **ZTE C300 V2.1.0**, where `-Cr0` never returns (the request
+  times out and retries, yielding empty results after ~45s) while `-Cr10`/`-Cr50`
+  return rows in <0.1s. Connections are now built with a sane default of **20**,
+  tunable via the new **`SNMP_MAX_REPETITIONS`** env var (mirrors
+  `SNMP_TIMEOUT_SECONDS` / `SNMP_RETRIES`; any value ≤ 0 or non-numeric falls
+  back to 20 so the hang can never be reintroduced through config). Pool members
+  inherit the value from the seed, defaulting to 20 if the seed lacks one.
+  This makes GetBulk usable on the C300, removing the need for the per-OLT
+  `walk=true` (GetNext) workaround that was previously required just to read it
+  (~0.06s reads via GetBulk).
+
 ## [3.2.0] - 2026-06-10
 
 First release as the **relocated standalone module**: repository renamed

--- a/internal/repository/snmp.go
+++ b/internal/repository/snmp.go
@@ -22,13 +22,14 @@ type SnmpRepositoryInterface interface {
 
 // snmpConfig holds connection parameters for creating new SNMP connections
 type snmpConfig struct {
-	target    string
-	port      uint16
-	community string
-	version   gosnmp.SnmpVersion
-	timeout   time.Duration
-	retries   int
-	maxOids   int
+	target         string
+	port           uint16
+	community      string
+	version        gosnmp.SnmpVersion
+	timeout        time.Duration
+	retries        int
+	maxOids        int
+	maxRepetitions uint32
 }
 
 // snmpRepository uses a connection pool for concurrent SNMP access
@@ -45,6 +46,13 @@ const DefaultPoolSize = 4
 // DefaultMaxConcurrent is the default limit for concurrent SNMP operations
 const DefaultMaxConcurrent = 5
 
+// DefaultMaxRepetitions is the GETBULK max-repetitions applied to pool
+// connections when the seed connection carries no explicit value. It is
+// intentionally never 0: GetBulk with max-repetitions=0 hangs on some ZTE
+// OLTs (e.g. C300 V2.1.0), so the per-OLT walk=true (GetNext) workaround was
+// needed to read them. Setting a sane default makes GetBulk usable again.
+const DefaultMaxRepetitions uint32 = 20
+
 // NewPonRepository creates a repository with a connection pool and default concurrency limit.
 // The seed connection is used to extract config, then poolSize connections are created.
 func NewPonRepository(seed *gosnmp.GoSNMP) SnmpRepositoryInterface {
@@ -56,13 +64,21 @@ func NewPonRepository(seed *gosnmp.GoSNMP) SnmpRepositoryInterface {
 // lossy/high-latency links (set per-OLT in the registry).
 func NewPonRepositoryWithConcurrency(seed *gosnmp.GoSNMP, maxConcurrent int, useWalk bool) SnmpRepositoryInterface {
 	cfg := snmpConfig{
-		target:    seed.Target,
-		port:      seed.Port,
-		community: seed.Community,
-		version:   seed.Version,
-		timeout:   seed.Timeout,
-		retries:   seed.Retries,
-		maxOids:   seed.MaxOids,
+		target:         seed.Target,
+		port:           seed.Port,
+		community:      seed.Community,
+		version:        seed.Version,
+		timeout:        seed.Timeout,
+		retries:        seed.Retries,
+		maxOids:        seed.MaxOids,
+		maxRepetitions: seed.MaxRepetitions,
+	}
+	// Never propagate a 0 max-repetitions to the pool: a GetBulk with
+	// max-repetitions=0 hangs on some ZTE OLTs. If the seed was built without
+	// it (e.g. a hand-rolled connection), fall back to a sane default so every
+	// pooled connection can perform GetBulk reliably.
+	if cfg.maxRepetitions == 0 {
+		cfg.maxRepetitions = DefaultMaxRepetitions
 	}
 
 	pool := make(chan *gosnmp.GoSNMP, DefaultPoolSize)
@@ -95,13 +111,14 @@ func NewPonRepositoryWithConcurrency(seed *gosnmp.GoSNMP, maxConcurrent int, use
 // createConnection creates a new SNMP connection from config
 func createConnection(cfg snmpConfig) (*gosnmp.GoSNMP, error) {
 	conn := &gosnmp.GoSNMP{
-		Target:    cfg.target,
-		Port:      cfg.port,
-		Community: cfg.community,
-		Version:   cfg.version,
-		Timeout:   cfg.timeout,
-		Retries:   cfg.retries,
-		MaxOids:   cfg.maxOids,
+		Target:         cfg.target,
+		Port:           cfg.port,
+		Community:      cfg.community,
+		Version:        cfg.version,
+		Timeout:        cfg.timeout,
+		Retries:        cfg.retries,
+		MaxOids:        cfg.maxOids,
+		MaxRepetitions: cfg.maxRepetitions,
 	}
 	if err := conn.Connect(); err != nil {
 		return nil, fmt.Errorf("SNMP pool connect failed: %w", err)

--- a/internal/repository/snmp_test.go
+++ b/internal/repository/snmp_test.go
@@ -509,6 +509,74 @@ func TestSnmpRepository_BulkWalk_Connected(t *testing.T) {
 	_ = err
 }
 
+// TestCreateConnection_SetsMaxRepetitions verifies that createConnection always
+// stamps a non-zero GETBULK max-repetitions onto the connection. A
+// max-repetitions of 0 makes GetBulk hang on some ZTE OLTs (C300 V2.1.0), so
+// this value must always be propagated from the config.
+func TestCreateConnection_SetsMaxRepetitions(t *testing.T) {
+	cfg := snmpConfig{
+		target:         "127.0.0.1",
+		port:           161,
+		community:      "public",
+		version:        gosnmp.Version2c,
+		timeout:        2 * time.Second,
+		retries:        1,
+		maxOids:        60,
+		maxRepetitions: 33,
+	}
+
+	conn, err := createConnection(cfg)
+	if err != nil {
+		t.Fatalf("createConnection failed: %v", err)
+	}
+	defer func() {
+		if conn.Conn != nil {
+			_ = conn.Conn.Close()
+		}
+	}()
+
+	if conn.MaxRepetitions != 33 {
+		t.Errorf("Expected MaxRepetitions 33, got %d", conn.MaxRepetitions)
+	}
+	if conn.MaxRepetitions == 0 {
+		t.Error("MaxRepetitions must never be 0 (GetBulk hangs on ZTE C300)")
+	}
+}
+
+// TestNewPonRepository_DefaultsMaxRepetitions verifies that when the seed
+// connection carries no explicit max-repetitions (the gosnmp zero value, 0),
+// the repository substitutes the safe DefaultMaxRepetitions instead of
+// propagating 0 to the pool — otherwise GetBulk would hang on a ZTE C300.
+func TestNewPonRepository_DefaultsMaxRepetitions(t *testing.T) {
+	conn := newTestConn("192.168.1.1", "public", 161) // MaxRepetitions left at 0
+	repo := NewPonRepository(conn)
+
+	snmpRepo, ok := repo.(*snmpRepository)
+	if !ok {
+		t.Fatal("Failed to type assert to *snmpRepository")
+	}
+	if snmpRepo.cfg.maxRepetitions != DefaultMaxRepetitions {
+		t.Errorf("Expected maxRepetitions to default to %d, got %d",
+			DefaultMaxRepetitions, snmpRepo.cfg.maxRepetitions)
+	}
+}
+
+// TestNewPonRepository_PropagatesMaxRepetitions verifies that an explicit
+// max-repetitions on the seed connection is carried into the pool config.
+func TestNewPonRepository_PropagatesMaxRepetitions(t *testing.T) {
+	conn := newTestConn("192.168.1.1", "public", 161)
+	conn.MaxRepetitions = 50
+	repo := NewPonRepository(conn)
+
+	snmpRepo, ok := repo.(*snmpRepository)
+	if !ok {
+		t.Fatal("Failed to type assert to *snmpRepository")
+	}
+	if snmpRepo.cfg.maxRepetitions != 50 {
+		t.Errorf("Expected maxRepetitions 50, got %d", snmpRepo.cfg.maxRepetitions)
+	}
+}
+
 func TestNewPonRepositoryWithConcurrency_ZeroMaxConcurrent(t *testing.T) {
 	conn := newTestConn("192.168.1.1", "public", 161)
 	repo := NewPonRepositoryWithConcurrency(conn, 0, false)

--- a/pkg/snmp/snmp.go
+++ b/pkg/snmp/snmp.go
@@ -13,6 +13,11 @@ import (
 	"go.uber.org/zap"
 )
 
+// DefaultMaxRepetitions is the GETBULK max-repetitions applied when
+// SNMP_MAX_REPETITIONS is unset. It is intentionally never 0: a GetBulk with
+// max-repetitions=0 hangs on some ZTE OLTs (see snmpMaxRepetitions).
+const DefaultMaxRepetitions uint32 = 20
+
 // snmpTimeout / snmpRetries make the per-request SNMP timeout and retry count
 // tunable for slow links (e.g. an OLT reached over the public internet, where
 // the default 5s is too aggressive). Defaults preserve the previous behavior
@@ -33,6 +38,24 @@ func snmpRetries() int {
 		}
 	}
 	return 2
+}
+
+// snmpMaxRepetitions returns the GETBULK max-repetitions used by BulkWalk.
+// gosnmp leaves MaxRepetitions at its zero value (0) unless it is set
+// explicitly, and a GetBulk with max-repetitions=0 HANGS on some OLTs
+// (proven live on a ZTE C300 V2.1.0: -Cr0 never returns, the request times
+// out and retries, yielding empty results after ~45s, while -Cr10/-Cr50
+// return rows in <0.1s). We therefore always set a sane, conservative
+// default (20) and make it tunable via SNMP_MAX_REPETITIONS. A value of 0
+// (or any non-positive / non-numeric value) falls back to the default so
+// the hang can never be reintroduced through config.
+func snmpMaxRepetitions() uint32 {
+	if v := os.Getenv("SNMP_MAX_REPETITIONS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return uint32(n)
+		}
+	}
+	return DefaultMaxRepetitions
 }
 
 // SetupSnmpConnection is a function to set up snmp connection
@@ -81,14 +104,15 @@ func SetupSnmpConnectionWith(host string, port uint16, community string) (*gosnm
 	// Create a new SNMP target instance
 	// Note: SNMP library logging is disabled; we use zap via pkg/logger for application logging instead
 	target := &gosnmp.GoSNMP{
-		Target:    host,             // Target IP
-		Port:      port,             // Target Port
-		Community: community,        // Community String
-		Version:   gosnmp.Version2c, // SNMP Version 2c
-		Timeout:   snmpTimeout(),    // default 5s; raise via SNMP_TIMEOUT_SECONDS for slow/public links
-		Retries:   snmpRetries(),    // default 2; tune via SNMP_RETRIES
-		MaxOids:   60,               // Maximum OIDs per request (batch size for better performance)
-		Logger:    gosnmp.Logger{},  // Disable SNMP library logging (empty struct)
+		Target:         host,                 // Target IP
+		Port:           port,                 // Target Port
+		Community:      community,            // Community String
+		Version:        gosnmp.Version2c,     // SNMP Version 2c
+		Timeout:        snmpTimeout(),        // default 5s; raise via SNMP_TIMEOUT_SECONDS for slow/public links
+		Retries:        snmpRetries(),        // default 2; tune via SNMP_RETRIES
+		MaxOids:        60,                   // Maximum OIDs per request (batch size for better performance)
+		MaxRepetitions: snmpMaxRepetitions(), // default 20; never 0 (0 hangs GetBulk on ZTE C300) — tune via SNMP_MAX_REPETITIONS
+		Logger:         gosnmp.Logger{},      // Disable SNMP library logging (empty struct)
 	}
 
 	// Connect to the SNMP target

--- a/pkg/snmp/tunables_test.go
+++ b/pkg/snmp/tunables_test.go
@@ -32,6 +32,54 @@ func TestSnmpTimeout(t *testing.T) {
 	}
 }
 
+func TestSnmpMaxRepetitions(t *testing.T) {
+	tests := []struct {
+		name string
+		set  bool
+		val  string
+		want uint32
+	}{
+		{"unset default", false, "", DefaultMaxRepetitions},
+		{"valid override", true, "10", 10},
+		{"valid override high", true, "50", 50},
+		{"zero falls back", true, "0", DefaultMaxRepetitions},
+		{"non-numeric falls back", true, "abc", DefaultMaxRepetitions},
+		{"negative falls back", true, "-5", DefaultMaxRepetitions},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.set {
+				t.Setenv("SNMP_MAX_REPETITIONS", tt.val)
+			} else {
+				t.Setenv("SNMP_MAX_REPETITIONS", "")
+			}
+			if got := snmpMaxRepetitions(); got != tt.want {
+				t.Errorf("snmpMaxRepetitions()=%d want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSetupSnmpConnectionWith_SetsMaxRepetitions verifies the seed connection
+// is built with a non-zero, env-tunable GETBULK max-repetitions.
+func TestSetupSnmpConnectionWith_SetsMaxRepetitions(t *testing.T) {
+	t.Setenv("SNMP_MAX_REPETITIONS", "25")
+
+	conn, err := SetupSnmpConnectionWith("127.0.0.1", 161, "public")
+	if err != nil {
+		t.Fatalf("SetupSnmpConnectionWith failed: %v", err)
+	}
+	defer func() {
+		if conn.Conn != nil {
+			_ = conn.Conn.Close()
+		}
+	}()
+
+	if conn.MaxRepetitions != 25 {
+		t.Errorf("Expected MaxRepetitions 25 from env, got %d", conn.MaxRepetitions)
+	}
+}
+
 func TestSnmpRetries(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
Fixes the C300 V2.1.0 GetBulk hazard: the adapter issued GetBulk with MaxRepetitions=0, which the C300 mishandles (hangs → timeout → empty ONU list), forcing a per-OLT `walk=true` (GetNext) workaround. This sets MaxRepetitions to a sane default (20, overridable via SNMP_MAX_REPETITIONS) so GetBulk works directly. Adds unit tests for the tunable + repository paths.

Once deployed, the C300-NWB `walk=true` workaround can be retired (walk=false).